### PR TITLE
add thatonecalculator's logos (surrealdb, vyper)

### DIFF
--- a/src/config/manual/thatonecalculator.ts
+++ b/src/config/manual/thatonecalculator.ts
@@ -17,8 +17,8 @@ export const thatonecalculator: Entries[number] = {
         },
         {
             title: "vyper",
-            imgSrc: GitHub.camoUrl("e3ab90845b9c976247fdb39c21821cd934d7c392c632ed7511b5e4cdd0f7b12b/68747470733a2f2f63646e2e696e65727469612e736f6369616c2f6b61776169695f6c6f676f732f56797065722e706e673f763d32"),
-            source: blueskyPost("t1c.dev", "3lc6soxakhs2h"),
+            imgSrc: GitHub.camoUrl("be1d9d90f545740cad8b8c4835d6b8a6338c10500190c522ce305af465396735/68747470733a2f2f63646e2e696e65727469612e736f6369616c2f6b61776169695f6c6f676f732f56797065725f6e65772e706e67"),
+            source: blueskyPost("t1c.dev", "3lc6ug7omck2t"),
             objectFit: "cover",
         },
     ],

--- a/src/config/manual/thatonecalculator.ts
+++ b/src/config/manual/thatonecalculator.ts
@@ -1,0 +1,25 @@
+import { GitHub } from "../../lib/url-github"
+import type { Entries } from "../../../types"
+import { blueskyPost } from "../../lib/url"
+
+export const thatonecalculator: Entries[number] = {
+    handleName: "thatonecalculator",
+    link: {
+        bluesky: "t1c.dev",
+        github: "thatonecalculator",
+    },
+    images: [
+        {
+            title: "surrealdb",
+            imgSrc: GitHub.camoUrl("f31c33f2e40d78c54ca8de8c761763bed0c98cbb481582c32311ddb26af769ac/68747470733a2f2f63646e2e696e65727469612e736f6369616c2f6b61776169695f6c6f676f732f5375727265616c44422e706e67"),
+            source: blueskyPost("t1c.dev", "3lc42nknqrc2d"),
+            objectFit: "cover",
+        },
+        {
+            title: "vyper",
+            imgSrc: GitHub.camoUrl("e3ab90845b9c976247fdb39c21821cd934d7c392c632ed7511b5e4cdd0f7b12b/68747470733a2f2f63646e2e696e65727469612e736f6369616c2f6b61776169695f6c6f676f732f56797065722e706e673f763d32"),
+            source: blueskyPost("t1c.dev", "3lc6soxakhs2h"),
+            objectFit: "cover",
+        },
+    ],
+}

--- a/src/lib/url-github.ts
+++ b/src/lib/url-github.ts
@@ -13,6 +13,8 @@ export const GitHub = {
     `https://raw.githubusercontent.com/alfonsusac/kawaii-logos-data/main/assets/${ filename }`,
   userAvatarUrl: (username: string) =>
     `https://avatars.githubusercontent.com/${ username }`,
+  camoUrl: (path: string) =>
+    `https://camo.githubusercontent.com/${ path }`,
 }
 
 export const getAvatarURLfromRepoPath = (repoPath: string) => {

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -1,2 +1,5 @@
 export const twitterPost = (username: string, postId: string) =>
   `https://twitter.com/${username}/status/${postId}`
+
+export const blueskyPost = (username: string, postId: string) =>
+  `https://bsky.app/profile/${username}/post/${postId}`

--- a/types/index.ts
+++ b/types/index.ts
@@ -28,6 +28,7 @@ export type Author = {
   link: {
     github?: string
     twitter?: string
+    bluesky?: string
   }
   repository?: string
   license?: {


### PR DESCRIPTION
| SurrealDB | Vyper |
|--------|--------|
| ![SurrealDB](https://github.com/user-attachments/assets/91f0f84c-8001-4e99-8147-02925b56c678) | ![Vyper](https://camo.githubusercontent.com/be1d9d90f545740cad8b8c4835d6b8a6338c10500190c522ce305af465396735/68747470733a2f2f63646e2e696e65727469612e736f6369616c2f6b61776169695f6c6f676f732f56797065725f6e65772e706e67) |

